### PR TITLE
Fixing bug for monthly_day dates for December

### DIFF
--- a/lib/recurrencex.ex
+++ b/lib/recurrencex.ex
@@ -90,17 +90,20 @@ defmodule Recurrencex do
     cond do
       day_shift <= 0 ->
         shifted_date = Timex.shift(date, [days: day_shift, months: recurrencex.frequency])
-        if shifted_date.month == rem(date.month + recurrencex.frequency, 12) do
-          shifted_date
-        else
-          Timex.shift(shifted_date, [days: -3])
-          |> Timex.end_of_month
-          |> Timex.set([
-            hour: date.hour,
-            minute: date.minute,
-            second: date.second,
-            microsecond: date.microsecond
-          ])
+        cond do
+          shifted_date.month == 12 and rem(date.month + recurrencex.frequency, 12) == 0 ->
+            shifted_date
+          shifted_date.month == rem(date.month + recurrencex.frequency, 12) ->
+            shifted_date
+          true ->
+            Timex.shift(shifted_date, [days: -3])
+            |> Timex.end_of_month
+            |> Timex.set([
+              hour: date.hour,
+              minute: date.minute,
+              second: date.second,
+              microsecond: date.microsecond
+            ])
         end
       day_shift > 0 ->
         Timex.shift(date, [days: day_shift])
@@ -169,5 +172,4 @@ defmodule Recurrencex do
     sequence
     |> Enum.find(Enum.at(sequence, 0), fn x -> x > base end)
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Recurrex.MixProject do
+defmodule Recurrencex.MixProject do
   use Mix.Project
 
   def project do

--- a/test/recurrex_test.exs
+++ b/test/recurrex_test.exs
@@ -31,10 +31,10 @@ defmodule RecurrencexTest do
     end
 
     test "date matches" do
-      date = Timex.to_datetime({{2018, 4, 1}, {0, 0, 0}}, "America/Toronto")
+      date = Timex.to_datetime({{2018, 11, 4}, {0, 0, 0}}, "America/Toronto")
       r = %Recurrencex{type: :monthly_day, frequency: 1, repeat_on: [1]}
       next = Recurrencex.next(date, r)
-      assert next == Timex.to_datetime({{2018, 5, 1}, {0, 0, 0}}, "America/Toronto")
+      assert next == Timex.to_datetime({{2018, 12, 1}, {0, 0, 0}}, "America/Toronto")
     end
   end
 


### PR DESCRIPTION
Next recurrences falling in December would be accidentally skipped to
the end of the month due to the monthly rollover behaviour.

i.e. a monthly repeating event for the 4th of every month for the 4th of
November would evalutate the next date incorrectly as December 31st
instead of December 4th.

Hi me.